### PR TITLE
feat: confirm modal remove course

### DIFF
--- a/src/atoms/atoms.ts
+++ b/src/atoms/atoms.ts
@@ -1,7 +1,11 @@
 import { atom, selector } from "recoil";
 import { customCourse } from "../shared/data";
 import { createEmptyTemplate } from "../shared/functions";
+<<<<<<< HEAD
 import { Course, Preset, Year } from "../shared/interfaces";
+=======
+import { BuildingBlock, Course, Year } from "../shared/interfaces";
+>>>>>>> feat: confirm modal remove course
 
 export const hasStartedEditingState = atom({
   key: "hasStartedEditingState",
@@ -115,6 +119,11 @@ export const presetRemoveState = atom<Preset | null>({
 export const tutorialsModalOpenState = atom({
   key: "tutorialsModalOpenState",
   default: false,
+});
+
+export const removeCourseState = atom<BuildingBlock | null>({
+  key: "removeCourseState",
+  default: null,
 });
 
 export const courseModalOpenState = atom({

--- a/src/pages/builder/Years.tsx
+++ b/src/pages/builder/Years.tsx
@@ -8,6 +8,7 @@ import {
   activeCustomCourseEditState,
   courseModalOpenState,
   coursesBuilderState,
+  removeCourseState,
 } from "../../atoms/atoms";
 import Divider from "../../components/Divider";
 import Text from "../../components/Text";
@@ -31,13 +32,14 @@ export default function Years({ onClearCoursesClick }: YearsProps) {
   const {
     coursesActiveYear,
     saveChanges,
-    removeCourse,
     addCourse,
     draggingCourse,
     removeFromSavedCoursesByObject,
     addToSavedCourses,
+    removeCourse
   } = useCourses();
   const setCourses = useSetRecoilState(coursesBuilderState);
+  const setCourseToRemove = useSetRecoilState(removeCourseState);
   const [coursesLocalStorage, setCoursesLocaStorage] = useLocalStorage(
     localStorageLayoutKey
   );
@@ -147,7 +149,7 @@ export default function Years({ onClearCoursesClick }: YearsProps) {
                 addToSavedCourses(course.content);
                 removeCourse(course.i);
               }}
-              onRemoveClick={removeCourse}
+              onRemoveClick={() => setCourseToRemove(course)}
             />
           </div>
         ))}

--- a/src/pages/builder/index.tsx
+++ b/src/pages/builder/index.tsx
@@ -20,6 +20,7 @@ import {
   statisticsDrawerState,
   shortcutUploadPlanState,
   presetRemoveState,
+  removeCourseState,
 } from "../../atoms/atoms";
 import ConfirmationModal from "../../components/ConfirmationModal";
 import UploadModal from "../../components/UploadModal";
@@ -58,6 +59,7 @@ export default function ExamBuilder() {
     setActiveYear,
     addYear,
     removeYear,
+    removeCourse,
     getSavedCourses,
     addToSavedCourses,
     removeAllCoursesInYear,
@@ -79,6 +81,7 @@ export default function ExamBuilder() {
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [isCoursesDrawerOpen, setIsCoursesDrawerOpen] =
     useRecoilState(coursesDrawerState);
+  const [courseToRemove, setCourseToRemove] = useRecoilState(removeCourseState);
   const [isExportDrawerOpen, setIsExportDrawerOpen] =
     useRecoilState(exportDrawerState);
   const [isSettingsDrawerOpen, setIsSettingsDrawerOpen] =
@@ -280,6 +283,22 @@ export default function ExamBuilder() {
             setActiveYear(courses.length - 2);
             removeYear();
             setIsConfirmRemoveYearModalOpen(false);
+          }}
+        />
+      )}
+      {courseToRemove && (
+        <ConfirmationModal
+          text={
+            "Är du säker på att du vill ta bort " +
+            courseToRemove.content.name +
+            "?"
+          }
+          subtext="Kursen kommer försvinna ur den nuvarande planen"
+          isOpen={courseToRemove !== null}
+          onCancel={() => setCourseToRemove(null)}
+          onConfirm={() => {
+            removeCourse(courseToRemove.i);
+            setCourseToRemove(null);
           }}
         />
       )}


### PR DESCRIPTION
  * when removing a course a confirm modal will be shown, if confirm is chosen the course will be removed from the active plan, if cancel is chosen the modal will just close without any other changes made